### PR TITLE
Address issues preventing SSE demo

### DIFF
--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -8,7 +8,7 @@ func _ready():
 	var sub_url = ""
 	print('Connecting to:', config.url + sub_url)
 	$HTTPSSEClient.connect("connected", self, "on_connected")
-	$HTTPSSEClient.connect_to_host(config.url, sub_url, 80, false, false)
+	$HTTPSSEClient.connect_to_host("localhost", "/", 5000, false, false)
 
 func on_connected():
 	$HTTPSSEClient.connect("new_sse_event", self, "on_new_sse_event")

--- a/sse_server.js
+++ b/sse_server.js
@@ -8,7 +8,6 @@ http.createServer((req, res) => {
 
   // send an event every second
   setInterval(() => {
-    res.write('event: example\n');
-    res.write(`data: ${new Date().toISOString()}\n\n`);
+    res.write(`event: newexample data: "${new Date().toISOString()}"\n\n`);
   }, 1000);
 }).listen(5000);


### PR DESCRIPTION
Two main things, the first is that as written it was using port 80, which doesnt match the 5000 the node process is listening on
the second is that the HTTPSSEClient addon is expecting the whole event + data to come all at once
a third thing is that the data portion should be JSON parsable, so I wrapped it in quotes